### PR TITLE
fixing a bug when changing resource keys

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -184,6 +184,9 @@ class Resource {
 	 */
 	public function setKey($key) {
 
+		// Changing keys requires a reset of the descriptor context
+		$this->resetDescriptorContext($key);
+
 		$this->key = $key;
 	}
 
@@ -388,6 +391,12 @@ class Resource {
 	}
 
 
+	/**
+	 * Retrieve the descriptor for the resource.
+	 *
+	 * @return mixed
+	 * @throws ResourceKeyNotSpecified
+	 */
 	protected function getDescriptorClass() {
 		return array_get($this->getResourceMap(), $this->getKey(), null);
 	}
@@ -404,6 +413,19 @@ class Resource {
 		}
 
 		return $this->resourceMap;
+	}
+
+
+	/**
+	 * Ensure the descriptor is retrieved properly whenever the resource key changes.
+	 *
+	 * @param $key
+	 */
+	private function resetDescriptorContext($key) {
+
+		if($this->key && $key !== $this->key) {
+			$this->descriptor = null;
+		}
 	}
 
 }

--- a/src/views/inputs/string.blade.php
+++ b/src/views/inputs/string.blade.php
@@ -1,4 +1,5 @@
-<div class="form-group">
-    <label for="{{ $name }}">{{ $label }}</label>
-    <input class="form-control" id="{{ $id }}" name="{{ $name }}" type="text" value="{{ $value }}"/>
+<div class="form-group{{ ($errors->has($id)) ? ' has-error': '' }}">
+    <label class="control-label" for="{{ $name }}">{{ $label }}</label>
+    <input id="{{ $id }}" class="form-control" name="{{ $name }}" type="text" value="{{ $value }}"/>
+    {{ $errors->first($id, '<span class="help-block">:message</span>') }}
 </div>

--- a/src/views/inputs/textarea.blade.php
+++ b/src/views/inputs/textarea.blade.php
@@ -1,4 +1,5 @@
-<div class="form-group">
-    <label for="{{ $name }}">{{ $label }}</label>
-    <textarea name="{{ $name }}" id="{{ $id }}" class="form-control" rows="3">{{ $value }}</textarea>
+<div class="form-group{{ ($errors->has($id)) ? ' has-error': '' }}">
+    <label class="control-label" for="{{ $name }}">{{ $label }}</label>
+    <textarea id="{{ $id }}" class="form-control" name="{{ $name }}" rows="8">{{ $value }}</textarea>
+    {{ $errors->first($id, '<span class="help-block">:message</span>') }}
 </div>


### PR DESCRIPTION
Changing resource keys, or attempting to get consecutively a group of resources ended in all resources having the same descriptor context because of the logic placed to try and not pull the descriptor if the resource had already loaded one. So I added a small check to allow for not loading the descriptor unless the key itself changes.
